### PR TITLE
Fix apiVersion format to add 'v' before version number

### DIFF
--- a/config/components/server.config.js
+++ b/config/components/server.config.js
@@ -28,7 +28,7 @@ const config = {
   isDevelopment: envVars.NODE_ENV === 'development',
   server: {
     port: envVars.PORT || 3000,
-    apiVersion: envVars.API_VERSION || 'v1',
+    apiVersion: 'v'+envVars.API_VERSION || 'v1',
   },
 };
 


### PR DESCRIPTION
This standardizes the apiVersion format to have a 'v' before the number. 
Currently, only a number is accepted in the .env config.
This makes the api routes consistent.  ".../api/v1/..."